### PR TITLE
Fix #2

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,7 +59,8 @@ async function showIngredients(e) {
     const ingredients = [];
     for(let i = 1; i <= 20; i++)
     {
-      ingredients.push(meal[`strMeasure${i}`] + " " + meal[`strIngredient${i}`]);
+      if(meal[`strMeasure${i}`]!=="" || meal[`strIngredient${i}`]!=="")
+        ingredients.push(meal[`strMeasure${i}`] + " " + meal[`strIngredient${i}`]);
     }
     const content = `Ingredients:
 


### PR DESCRIPTION
Issue #2 

**EXACT PROBLEM**

Actually, the for loop iterating through the meal was looping 20 times whether the measurements and ingredients are empty or not. So it was adding some extra spaces after the ingredients. 

**SOLUTION**

On line 62 in the for loop, I inserted an if condition, in which if either the measure or ingredients are empty, then it will execute the statement, and will insert the ingredient.

Here are the results:

_Before:_

![Screenshot_17](https://user-images.githubusercontent.com/92971894/157870105-f1aefdf6-1224-449c-b11e-08285445f70e.png)

_After:_

![Screenshot_18](https://user-images.githubusercontent.com/92971894/157870182-5bfd8f5a-e21c-45de-bafb-769ded97b899.png)

